### PR TITLE
Future Mutex

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMELLON_BUILD_TESTS=On
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,4 +45,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --test-dir test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(futures)
 set(CMAKE_CXX_STANDARD 17)
 
 
-add_library(mellon src/futures.cpp include/mellon/utilities.h include/mellon/completion-queue.h include/mellon/traits.h include/mellon/state-machine.h include/mellon/detail/box.h include/mellon/detail/invalid-pointer-flags.h include/mellon/detail/gadgets.h include/mellon/collector.h)
+add_library(mellon src/futures.cpp include/mellon/utilities.h include/mellon/completion-queue.h include/mellon/traits.h include/mellon/state-machine.h include/mellon/detail/box.h include/mellon/detail/invalid-pointer-flags.h include/mellon/detail/gadgets.h include/mellon/collector.h include/mellon/locks.h)
 target_include_directories(mellon PUBLIC include)
 
 option(MELLON_LIBUNWIND_LIB "unwind library to use" unwind)

--- a/include/mellon/locks.h
+++ b/include/mellon/locks.h
@@ -1,0 +1,70 @@
+#ifndef FUTURES_LOCKS_H
+#define FUTURES_LOCKS_H
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include "futures.h"
+
+namespace mellon {
+
+struct immediate_executor {
+  template <typename F>
+  void operator()(F&& f) const noexcept {
+    static_assert(std::is_nothrow_invocable_r_v<void, F>);
+    std::invoke(std::forward<F>(f));
+  }
+};
+
+template <typename Tag, typename Executor = immediate_executor>
+struct future_mutex {
+  using lock_guard = std::unique_lock<future_mutex<Tag, Executor>>;
+  using future_type = future<lock_guard, Tag>;
+
+  explicit future_mutex(Executor ex = Executor()) : _executor(std::move(ex)) {}
+
+  void lock() {
+    async_lock().await(mellon::yes_i_know_that_this_call_will_block).release();
+  }
+
+  void unlock() {
+    std::unique_lock guard(_mutex);
+    // assert(_is_locked == true);
+    if (!_queue.empty()) {
+      auto p = std::move(_queue.front());
+      _queue.pop_front();
+      guard.unlock();
+
+      _executor([this, p = std::move(p)]() mutable noexcept {
+        std::move(p).fulfill(*this, std::adopt_lock);
+      });
+    } else {
+      _is_locked = false;
+    }
+  }
+
+  auto async_lock() -> future_type {
+    std::unique_lock guard(_mutex);
+    if (_is_locked) {
+      auto&& [f, p] = make_promise<lock_guard, Tag>();
+      _queue.emplace_back(std::move(p));
+      return std::move(f);
+    } else {
+      _is_locked = true;
+      return future_type{std::in_place, *this, std::adopt_lock};
+    }
+  }
+
+  [[nodiscard]] auto is_locked() const noexcept -> bool { return _is_locked; }
+
+ private:
+  std::atomic<bool> _is_locked;
+  std::mutex _mutex;
+  std::deque<promise<lock_guard, Tag>> _queue;
+
+  Executor _executor;
+};
+
+}  // namespace mellon
+
+#endif  // FUTURES_LOCKS_H

--- a/include/mellon/locks.h
+++ b/include/mellon/locks.h
@@ -56,10 +56,14 @@ struct future_mutex {
   }
 
   [[nodiscard]] auto is_locked() const noexcept -> bool { return _is_locked; }
+  [[nodiscard]] auto queue_length() const noexcept -> std::size_t {
+    std::unique_lock guard(_mutex);
+    return _queue.size();
+  }
 
  private:
-  std::atomic<bool> _is_locked;
-  std::mutex _mutex;
+  std::atomic<bool> _is_locked = false;
+  mutable std::mutex _mutex;
   std::deque<promise<lock_guard, Tag>> _queue;
 
   Executor _executor;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(mellon-test
   collector-test.cpp
   future-test.cpp
   fuzzer-test.cpp
-)
+        locks.cpp)
 target_compile_options(mellon-test PRIVATE "-fsanitize=address")
 target_link_libraries(mellon-test PRIVATE asan)
 target_link_libraries(mellon-test PRIVATE gtest)

--- a/test/locks.cpp
+++ b/test/locks.cpp
@@ -13,6 +13,7 @@ TEST(locks, simple_test) {
         ASSERT_TRUE(mutex.is_locked());
       });
 
+  ASSERT_EQ(mutex.queue_length(), 0);
   ASSERT_FALSE(mutex.is_locked());
   ASSERT_TRUE(executed);
 }

--- a/test/locks.cpp
+++ b/test/locks.cpp
@@ -30,7 +30,7 @@ TEST(locks, async_lock_test) {
         executed = true;
         EXPECT_TRUE(mutex.is_locked());
         return std::monostate();
-      });
+      }).finalize();
 
   ASSERT_FALSE(executed);
   mutex.unlock();  // now the future should execute by the executor
@@ -55,7 +55,7 @@ TEST(locks, async_lock_test2) {
         EXPECT_EQ(executed, 0);
         executed = 1;
         return std::monostate();
-      });
+      }).finalize();
 
   auto f2 = mutex.async_lock().and_then(
       [&](std::unique_lock<mellon::future_mutex<default_test_tag>>&& lock) noexcept -> std::monostate {
@@ -63,7 +63,7 @@ TEST(locks, async_lock_test2) {
         EXPECT_EQ(executed, 1);
         executed = 2;
         return std::monostate();
-      });
+      }).finalize();
 
   ASSERT_FALSE(executed);
   mutex.unlock();  // now the future should execute by the executor

--- a/test/locks.cpp
+++ b/test/locks.cpp
@@ -1,0 +1,76 @@
+#include "test-helper.h"
+
+#include <mellon/locks.h>
+
+TEST(locks, simple_test) {
+  mellon::future_mutex<default_test_tag> mutex;
+  bool executed = false;
+
+  // this should execute immediately
+  mutex.async_lock().finally(
+      [&](std::unique_lock<mellon::future_mutex<default_test_tag>>&& lock) noexcept {
+        executed = true;
+        ASSERT_TRUE(mutex.is_locked());
+      });
+
+  ASSERT_FALSE(mutex.is_locked());
+  ASSERT_TRUE(executed);
+}
+
+TEST(locks, async_lock_test) {
+  mellon::future_mutex<default_test_tag> mutex;
+  mutex.lock();
+
+  ASSERT_TRUE(mutex.is_locked());
+
+  std::atomic<bool> executed = false;
+  // this should not execute immediately
+  auto f = mutex.async_lock().and_then(
+      [&](std::unique_lock<mellon::future_mutex<default_test_tag>>&& lock) noexcept -> std::monostate {
+        executed = true;
+        EXPECT_TRUE(mutex.is_locked());
+        return std::monostate();
+      });
+
+  ASSERT_FALSE(executed);
+  mutex.unlock();  // now the future should execute by the executor
+
+  // this should eventually be resolved
+  std::move(f).await(mellon::yes_i_know_that_this_call_will_block);
+  ASSERT_TRUE(executed);
+  ASSERT_FALSE(mutex.is_locked());
+}
+
+TEST(locks, async_lock_test2) {
+  mellon::future_mutex<default_test_tag> mutex;
+  mutex.lock();
+
+  ASSERT_TRUE(mutex.is_locked());
+
+  std::atomic<int> executed = 0;
+  // this should not execute immediately
+  auto f = mutex.async_lock().and_then(
+      [&](std::unique_lock<mellon::future_mutex<default_test_tag>>&& lock) noexcept -> std::monostate {
+        EXPECT_TRUE(mutex.is_locked());
+        EXPECT_EQ(executed, 0);
+        executed = 1;
+        return std::monostate();
+      });
+
+  auto f2 = mutex.async_lock().and_then(
+      [&](std::unique_lock<mellon::future_mutex<default_test_tag>>&& lock) noexcept -> std::monostate {
+        EXPECT_TRUE(mutex.is_locked());
+        EXPECT_EQ(executed, 1);
+        executed = 2;
+        return std::monostate();
+      });
+
+  ASSERT_FALSE(executed);
+  mutex.unlock();  // now the future should execute by the executor
+
+  // this should eventually be resolved
+  std::move(f).await(mellon::yes_i_know_that_this_call_will_block);
+  std::move(f2).await(mellon::yes_i_know_that_this_call_will_block);
+  ASSERT_EQ(executed, 2);
+  ASSERT_FALSE(mutex.is_locked());
+}


### PR DESCRIPTION
Implementation of a mutex supporting a `async_lock` operation that returns a future. The value type of that future is a `std::unique_lock` guard that locks the mutex.